### PR TITLE
Update to workflowr v0.4.0

### DIFF
--- a/analysis/QC_single_cell_library.Rmd
+++ b/analysis/QC_single_cell_library.Rmd
@@ -696,8 +696,8 @@ In this analysis we performed QC by checking the following criteria:
 
 
 
-###Session Info:
-```{r}
-sessionInfo()
-```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/QC_single_cell_library.Rmd
+++ b/analysis/QC_single_cell_library.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-04
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("dplyr")
@@ -697,7 +705,8 @@ In this analysis we performed QC by checking the following criteria:
 
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/apply_citrus_singlecell.Rmd
+++ b/analysis/apply_citrus_singlecell.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-28
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 In this analysis I will use the scPLS method in the Citrus package to regress technical factor out of the single cell data. I will use filtered molecule counts for the first individual in the dataset.  
 
@@ -402,7 +410,8 @@ Final model: k1=1 and k2=5
 ff6
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/apply_citrus_singlecell.Rmd
+++ b/analysis/apply_citrus_singlecell.Rmd
@@ -402,3 +402,7 @@ Final model: k1=1 and k2=5
 ff6
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/batch_effect_conversion_efficency.Rmd
+++ b/analysis/batch_effect_conversion_efficency.Rmd
@@ -289,8 +289,8 @@ plot_grid(convertion_ensg + theme(legend.position = "none"),
 
 This analysis provides evidence for batch effects in individual and technical replicates for ERCC and for endogenous gene conversion rate.  
 
-###Session Info  
-```{r}
-sessionInfo()
-```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/batch_effect_conversion_efficency.Rmd
+++ b/analysis/batch_effect_conversion_efficency.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-08
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 
 ###Objective  
@@ -290,7 +298,8 @@ plot_grid(convertion_ensg + theme(legend.position = "none"),
 This analysis provides evidence for batch effects in individual and technical replicates for ERCC and for endogenous gene conversion rate.  
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/bio_singlecellony.Rmd
+++ b/analysis/bio_singlecellony.Rmd
@@ -170,3 +170,7 @@ gene_info_non_sing_ENSG <- getBM(attributes = c("ensembl_gene_id",
                       mart = ensembl)
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/bio_singlecellony.Rmd
+++ b/analysis/bio_singlecellony.Rmd
@@ -5,16 +5,24 @@ date: 2017-03-02
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 
 ###Pull in genes lists  
@@ -170,7 +178,8 @@ gene_info_non_sing_ENSG <- getBM(attributes = c("ensembl_gene_id",
                       mart = ensembl)
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/bri_gene_x_sample_count_matrix.Rmd
+++ b/analysis/bri_gene_x_sample_count_matrix.Rmd
@@ -5,16 +5,24 @@ date: YYYY-MM-DD
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("data.table")
@@ -190,7 +198,8 @@ Output molecule counts.
 write.table(molecules_bri, "../data/molecules_bri.txt", quote= FALSE, sep= "\t", col.names = NA)
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/bri_gene_x_sample_count_matrix.Rmd
+++ b/analysis/bri_gene_x_sample_count_matrix.Rmd
@@ -190,7 +190,7 @@ Output molecule counts.
 write.table(molecules_bri, "../data/molecules_bri.txt", quote= FALSE, sep= "\t", col.names = NA)
 ```
 
-###Session Information
-```{r}
-sessionInfo()
+## Session Information
+
+```{r session-info}
 ```

--- a/analysis/cell_to_cell_variation.Rmd
+++ b/analysis/cell_to_cell_variation.Rmd
@@ -725,9 +725,8 @@ lines(lowess( ENSG_cv_adj$all$log10cv2_adj[ii_genes]*(1/2) ~ drop_out$all),
 title(main = "All cells, three individuals", outer = TRUE, line = -1)
 ```
 
-###Session Information  
 
-```{r}
-sessionInfo()
+## Session Information
+
+```{r session-info}
 ```
-

--- a/analysis/cell_to_cell_variation.Rmd
+++ b/analysis/cell_to_cell_variation.Rmd
@@ -5,16 +5,24 @@ date: 2017-2-17
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ###Objective  
 
@@ -726,7 +734,8 @@ title(main = "All cells, three individuals", outer = TRUE, line = -1)
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/chunks.R
+++ b/analysis/chunks.R
@@ -2,12 +2,33 @@
 # http://yihui.name/knitr/demo/externalization/
 
 # ---- knitr-opts-chunk ----
+# Update knitr chunk options
+# https://yihui.name/knitr/options/#chunk-options
 knitr::opts_chunk$set(
   comment = NA,
   fig.align = "center",
   tidy = FALSE,
   fig.path = paste0("figure/", knitr::current_input(), "/")
 )
+
+# ---- last-updated ----
+# Insert the date the file was last updated
+cat(sprintf("**Last updated:** %s", Sys.Date()))
+
+# ---- code-version ----
+# Insert the code version (Git commit SHA1) if Git repository exists and R
+# package git2r is installed
+if(requireNamespace("git2r", quietly = TRUE)) {
+  if(git2r::in_repository()) {
+    code_version <- substr(git2r::commits()[[1]]@sha, 1, 7)
+  } else {
+    code_version <- "Unavailable. Initialize Git repository to enable."
+  }
+} else {
+  code_version <- "Unavailable. Install git2r package to enable."
+}
+cat(sprintf("**Code version:** %s", code_version))
+rm(code_version)
 
 # ---- session-info ----
 sessionInfo()

--- a/analysis/compare_19098_bulk_single.Rmd
+++ b/analysis/compare_19098_bulk_single.Rmd
@@ -5,16 +5,25 @@ date: YYYY-MM-DD
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
+
 ```{r}
 library("data.table")
 library("dplyr")
@@ -55,7 +64,8 @@ grid.newpage()
 grid.draw(genes_venn_19098)
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/compare_19098_bulk_single.Rmd
+++ b/analysis/compare_19098_bulk_single.Rmd
@@ -55,3 +55,7 @@ grid.newpage()
 grid.draw(genes_venn_19098)
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/compare_count_data.Rmd
+++ b/analysis/compare_count_data.Rmd
@@ -3,6 +3,25 @@ title: "Compare count data"
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
+```{r read-chunk, include=FALSE, cache=FALSE}
+knitr::read_chunk("chunks.R")
+```
+
+<!-- Update knitr chunk options -->
+```{r knitr-opts-chunk, include=FALSE}
+```
+
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
+
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
+
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
@@ -186,3 +205,9 @@ Difference in dedup step: UMI-tools explicitly says it deals with similar UMI's,
 
 
 
+
+## Session information
+
+<!-- Insert the session information into the document -->
+```{r session-info}
+```

--- a/analysis/data_transformation.Rmd
+++ b/analysis/data_transformation.Rmd
@@ -217,10 +217,9 @@ plot_final
 Skip writting this figure as a tiff file  
 
 
-###Session Information  
 
-```{r}
-sessionInfo()
+
+## Session Information
+
+```{r session-info}
 ```
-
-

--- a/analysis/data_transformation.Rmd
+++ b/analysis/data_transformation.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-15
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ###Data transformation  
 ```{r}
@@ -219,7 +227,8 @@ Skip writting this figure as a tiff file
 
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/explore_bulkvsingle_gene.Rmd
+++ b/analysis/explore_bulkvsingle_gene.Rmd
@@ -5,16 +5,24 @@ date: 2016-02-10
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 This analysis looks into genes that were only detected in either the single cell or bulk sequencing. Contrary to many's intuitiion there were more genes detected using single cell sequencing than when we pooled cells together. I wanted to explore the expression levels of these genes, variability in expression levels, and the proportion of single cells where these genes were detected. For the bulk specific genes I wanted to see how their expression compares to the expression levels of the genes found in both analysis. Information found here could provide information about bias or provide evidence for the importance of single cell sequencing to detect gene expression.  
 
@@ -224,7 +232,8 @@ plot((bulk_and_order$bulk_mean) , pch=46, cex=10, col=col_vec_onlyBULK, main = "
 
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/explore_bulkvsingle_gene.Rmd
+++ b/analysis/explore_bulkvsingle_gene.Rmd
@@ -224,3 +224,7 @@ plot((bulk_and_order$bulk_mean) , pch=46, cex=10, col=col_vec_onlyBULK, main = "
 
 
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/filter_genes_low_quality_genes.Rmd
+++ b/analysis/filter_genes_low_quality_genes.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-05
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("biomaRt")
@@ -243,7 +251,8 @@ pca_reads_bulk_filter_plot
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/filter_genes_low_quality_genes.Rmd
+++ b/analysis/filter_genes_low_quality_genes.Rmd
@@ -242,9 +242,8 @@ pca_reads_bulk_filter_plot <- plot_pca(pca_reads_bulk_filter$PCs, explained = pc
 pca_reads_bulk_filter_plot
 ```
 
-###Session Info  
 
-```{r}
-sessionInfo()
+## Session Information
+
+```{r session-info}
 ```
-

--- a/analysis/gene_x_sample_count_matrix.Rmd
+++ b/analysis/gene_x_sample_count_matrix.Rmd
@@ -2,18 +2,25 @@
 title: "Create gene-x-sample count matrices and annotation file"
 output: html_document
 ---
+
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Last updated:** `r Sys.Date()`
-
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
-
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 This is recreating code from http://jdblischak.github.io/singleCellSeq/analysis/prepare-counts.html.
 
 ```{r}
@@ -172,7 +179,8 @@ write.table(molecules, "../../singleCellSeq/data/molecules.txt", quote= FALSE, s
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/gene_x_sample_count_matrix.Rmd
+++ b/analysis/gene_x_sample_count_matrix.Rmd
@@ -171,8 +171,8 @@ Output molecule counts.
 write.table(molecules, "../../singleCellSeq/data/molecules.txt", quote= FALSE, sep= "\t", col.names = NA)
 ```
 
-###Session Information
-```{r}
-sessionInfo()
-```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/genome_wide_data_comparison.Rmd
+++ b/analysis/genome_wide_data_comparison.Rmd
@@ -242,3 +242,7 @@ boxplot(ERCC_67.T_df$git, ERCC_67.T_df$bri, las=2, names=c("git", "bri"), ylab="
 boxplot(ERCC_67.T_df$git, ERCC_74.T_df$bri, las=2, names=c("git-67", "git-74"), ylab="Read count")
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/genome_wide_data_comparison.Rmd
+++ b/analysis/genome_wide_data_comparison.Rmd
@@ -5,16 +5,24 @@ date: "2/6/2017"
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("biomaRt")
@@ -242,7 +250,8 @@ boxplot(ERCC_67.T_df$git, ERCC_67.T_df$bri, las=2, names=c("git", "bri"), ylab="
 boxplot(ERCC_67.T_df$git, ERCC_74.T_df$bri, las=2, names=c("git-67", "git-74"), ylab="Read count")
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/mixed_effect_batch_correction.Rmd
+++ b/analysis/mixed_effect_batch_correction.Rmd
@@ -110,8 +110,8 @@ pca_final_plot <- plot_pca(pca_final$PCs, explained=pca_final$explained, metadat
 pca_final_plot
 ```
 
-###Session Information
-```{r}
-sessionInfo()
-```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/mixed_effect_batch_correction.Rmd
+++ b/analysis/mixed_effect_batch_correction.Rmd
@@ -5,16 +5,24 @@ date: 2016-02-15
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("limma")
@@ -111,7 +119,8 @@ pca_final_plot
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/noisy_genes.Rmd
+++ b/analysis/noisy_genes.Rmd
@@ -424,9 +424,8 @@ mad_genes <- rownames(molecules_final)[rank(mad) >
 
 ```
 
-###Session Information  
 
-```{r}
-sessionInfo()
+## Session Information
+
+```{r session-info}
 ```
-

--- a/analysis/noisy_genes.Rmd
+++ b/analysis/noisy_genes.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-17
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 Work through some of this to get a better understanding of the data used for cell-cell variation.  
 
@@ -425,7 +433,8 @@ mad_genes <- rownames(molecules_final)[rank(mad) >
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/quality_control_plotes.Rmd
+++ b/analysis/quality_control_plotes.Rmd
@@ -5,16 +5,24 @@ date: "2/6/2017"
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ###Input
 ```{r}
@@ -269,7 +277,8 @@ plot_grid(plot_mean_log + theme(legend.position = c(.85,.25)) + labs (col = ""),
 
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/quality_control_plotes.Rmd
+++ b/analysis/quality_control_plotes.Rmd
@@ -267,10 +267,9 @@ plot_grid(plot_mean_log + theme(legend.position = c(.85,.25)) + labs (col = ""),
 ```
 
 
-###Session Information:  
 
-```{r}
-sessionInfo()
+
+## Session Information
+
+```{r session-info}
 ```
-
-

--- a/analysis/recreate_cell_cycle_analysis.Rmd
+++ b/analysis/recreate_cell_cycle_analysis.Rmd
@@ -111,3 +111,7 @@ or use the -D flag to gmap to specify the correct genome directory.**
 
 try unzipping the files :  
 gzip: ERR489047_1.fastq.gz: unexpected end of file  
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/recreate_cell_cycle_analysis.Rmd
+++ b/analysis/recreate_cell_cycle_analysis.Rmd
@@ -5,16 +5,24 @@ date: 2017-01-06
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 General information for committing changes to the git hub site 
 
@@ -111,7 +119,9 @@ or use the -D flag to gmap to specify the correct genome directory.**
 
 try unzipping the files :  
 gzip: ERR489047_1.fastq.gz: unexpected end of file  
-## Session Information
 
+## Session information
+
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/recreate_giladsinglecell.Rmd
+++ b/analysis/recreate_giladsinglecell.Rmd
@@ -5,16 +5,24 @@ date: "January 11, 2017"
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 
 I will use this to document my recreating of the single cell data processing from http://jdblischak.github.io/singleCellSeq/analysis/process-samples.html.  
@@ -403,7 +411,9 @@ In the end I have a directory called counts-matrix with 6 files in it that will 
 *  reads-raw-single-per-lane.txt
 
 * reads-raw-single-per-sample.txt 
-## Session Information
 
+## Session information
+
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/recreate_giladsinglecell.Rmd
+++ b/analysis/recreate_giladsinglecell.Rmd
@@ -403,3 +403,7 @@ In the end I have a directory called counts-matrix with 6 files in it that will 
 *  reads-raw-single-per-lane.txt
 
 * reads-raw-single-per-sample.txt 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/sc_only_ind.Rmd
+++ b/analysis/sc_only_ind.Rmd
@@ -305,3 +305,7 @@ non_sing_venn_19239<- venn.diagram(x = list("R1" = genes_not_singleton_19239.R1,
 grid.newpage()
 grid.draw(non_sing_venn_19239)
 ```
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/sc_only_ind.Rmd
+++ b/analysis/sc_only_ind.Rmd
@@ -5,16 +5,24 @@ date: 2017/03/03
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ###Pull in genes lists  
 
@@ -305,7 +313,9 @@ non_sing_venn_19239<- venn.diagram(x = list("R1" = genes_not_singleton_19239.R1,
 grid.newpage()
 grid.draw(non_sing_venn_19239)
 ```
-## Session Information
 
+## Session information
+
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/simulate_bulk_genes.Rmd
+++ b/analysis/simulate_bulk_genes.Rmd
@@ -5,16 +5,24 @@ date: 2017-2-16
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("biomaRt")
@@ -234,7 +242,8 @@ genes_observed_molecules <- rownames(molecules_1ind)[rowSums(molecules_1ind) > 0
 #    })
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/simulate_bulk_genes.Rmd
+++ b/analysis/simulate_bulk_genes.Rmd
@@ -234,3 +234,7 @@ genes_observed_molecules <- rownames(molecules_1ind)[rowSums(molecules_1ind) > 0
 #    })
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/standardize_CPM.Rmd
+++ b/analysis/standardize_CPM.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-13
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 
 ```{r}
@@ -161,7 +169,8 @@ write.table(round(molecules_cpm_ercc, digits = 6), "../data/molecules-cpm-ercc.t
 
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/standardize_CPM.Rmd
+++ b/analysis/standardize_CPM.Rmd
@@ -161,7 +161,7 @@ write.table(round(molecules_cpm_ercc, digits = 6), "../data/molecules-cpm-ercc.t
 
 ```
 
-###Session Information
-```{r}
-sessionInfo()
+## Session Information
+
+```{r session-info}
 ```

--- a/analysis/subsample_plots.Rmd
+++ b/analysis/subsample_plots.Rmd
@@ -174,3 +174,7 @@ plot_mol_depth_ercc
 sessionInfo()
 ```
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/subsample_plots.Rmd
+++ b/analysis/subsample_plots.Rmd
@@ -5,16 +5,24 @@ date: 2016-02-08
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 A subsample of the full data, post mapping, was processed to create the count data used here.  
 
@@ -174,7 +182,8 @@ plot_mol_depth_ercc
 sessionInfo()
 ```
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/technical_noise_control.Rmd
+++ b/analysis/technical_noise_control.Rmd
@@ -168,11 +168,6 @@ ggplot( do.call(rbind,variance_components), aes(1-residual,col=method)) + geom_d
 ```
 **What does this plot tell me?**   
 
-###Session Information  
-
-```{r}
-sessionInfo()
-```
 
 
 ####Notes on anova  
@@ -183,3 +178,7 @@ sessionInfo()
 
 * Calculate mean of means and SST ((each point - grand mean)^2)
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/technical_noise_control.Rmd
+++ b/analysis/technical_noise_control.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-13
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ```{r}
 library("dplyr")
@@ -178,7 +186,8 @@ ggplot( do.call(rbind,variance_components), aes(1-residual,col=method)) + geom_d
 
 * Calculate mean of means and SST ((each point - grand mean)^2)
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/try_cellity.Rmd
+++ b/analysis/try_cellity.Rmd
@@ -5,16 +5,24 @@ date: YYYY-MM-DD
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 Package available at: https://github.com/Teichlab/cellity.  
 ```{r}
@@ -34,7 +42,9 @@ names(sample_stats)
 Mapping and gene count pipeline: https://github.com/Teichlab/celloline  
 
 Talk to Joyce about this. Should we move all of the data over to project 2 and try to get this up and running?  
-## Session Information
 
+## Session information
+
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/try_cellity.Rmd
+++ b/analysis/try_cellity.Rmd
@@ -34,3 +34,7 @@ names(sample_stats)
 Mapping and gene count pipeline: https://github.com/Teichlab/celloline  
 
 Talk to Joyce about this. Should we move all of the data over to project 2 and try to get this up and running?  
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/try_citrus.Rmd
+++ b/analysis/try_citrus.Rmd
@@ -229,3 +229,7 @@ Smaller chunks of genes help the algorithm run faster. With a gene set as small 
 
 
 **k values vs liklihood**
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/try_citrus.Rmd
+++ b/analysis/try_citrus.Rmd
@@ -5,16 +5,24 @@ date: 2017-02-27
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
 
 ###Install package  
 
@@ -229,7 +237,9 @@ Smaller chunks of genes help the algorithm run faster. With a gene set as small 
 
 
 **k values vs liklihood**
-## Session Information
 
+## Session information
+
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/analysis/try_sva.Rmd
+++ b/analysis/try_sva.Rmd
@@ -28,3 +28,7 @@ library("sva")
 ```
 
 
+## Session Information
+
+```{r session-info}
+```

--- a/analysis/try_sva.Rmd
+++ b/analysis/try_sva.Rmd
@@ -5,16 +5,25 @@ date: 2017-03-01
 output: html_document
 ---
 
+<!-- The file analysis/chunks.R contains chunks that define default settings
+shared across the workflowr files. -->
 ```{r read-chunk, include=FALSE, cache=FALSE}
 knitr::read_chunk("chunks.R")
 ```
 
+<!-- Update knitr chunk options -->
 ```{r knitr-opts-chunk, include=FALSE}
 ```
 
-**Last updated:** `r Sys.Date()`
+<!-- Insert the date the file was last updated -->
+```{r last-updated, echo=FALSE, results='asis'}
+```
 
-**Code version:** `r workflowr::extract_commit(".", 1)$sha1`
+<!-- Insert the code version (Git commit SHA1) if Git repository exists and R
+ package git2r is installed -->
+```{r code-version, echo=FALSE, results='asis'}
+```
+
 ```{r install sva}
 #source("https://bioconductor.org/biocLite.R")
 #biocLite("sva")
@@ -28,7 +37,8 @@ library("sva")
 ```
 
 
-## Session Information
+## Session information
 
+<!-- Insert the session information into the document -->
 ```{r session-info}
 ```

--- a/~
+++ b/~
@@ -1,5 +1,0 @@
-# This is Git's per-user configuration file.
-[user]
-# Please adapt and uncomment the following lines:
-#	name = Briana Erin Mittleman
-#	email = brimittleman@midway2-login2.rcc.local


### PR DESCRIPTION
I first ran the custom code below to standardize the session information chunks and then ran `wflow_update(dry_run = FALSE)`. I also removed the .gitconfig file that was named `~`.

```
rmd <- list.files(path = "analysis", pattern = "Rmd$", full.names = TRUE)

lines_to_add <- c(
  "## Session Information",
  "",
  "```{r session-info}",
  "```")

for (r in rmd) {
  lines <- readLines(r)

  # Skip files that don't need to be fixed before updating.
  # This includes files like index.Rmd that don't have commit or sessionInfo
  if (!any(grepl("extract_commit", lines))) {
    message("Skipping ", r)
    next
  }

  info_line <- grep("###Session Info", lines)
  if (length(info_line) > 1) {
    warning("Problem with ", r)
    next
  } else if (length(info_line) == 1) {
    # Find the closing backticks. Should be able to take the second of the two
    # for the chunk
    backticks <- grep("```", lines[info_line:length(lines)])
    if (length(backticks) < 2) {
      warning("Problem with session info chunk in ", r)
      next
    }
    end_line <- info_line + backticks[2] - 1
    newlines <- c(lines[-(info_line:end_line)], lines_to_add)
  } else {
    newlines <- c(lines, lines_to_add)
  }
  cat(newlines, sep = "\n", file = r)
}
```